### PR TITLE
Also provide the result as argument of the callback

### DIFF
--- a/js/rdform.js
+++ b/js/rdform.js
@@ -1473,7 +1473,9 @@
 					}
 
 					// this calls the callback function
-					_this.settings.submit.call( _this.RESULT );
+					// by using call() it replaces the "this" value for the method
+					// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call
+					_this.settings.submit.call( _this.RESULT, _this.RESULT );
 				});
 			}
 		},


### PR DESCRIPTION
This is especially important, if the `this` context gets lost on the way
back when the callback is called.